### PR TITLE
L3 forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Usage:
 Path MTU Daemon is captures and broadcasts ICMP messages related to
 MTU detection. It listens on an interface, waiting for ICMP messages
 (IPv4 type 3 code 4 or IPv6 type 2 code 0) and it forwards them
-verbatim to the broadcast ethernet address.
+verbatim normally to the broadcast ethernet address. If a list of peers
+is given then ICMP messages are forwarded using normal routing to these
+peers enabling distribution across different subnets.
 
 Options:
 
@@ -30,6 +32,8 @@ Options:
   --cpu                Pin to particular cpu
   --ports              Forward only ICMP packets with payload
                        containing L4 source port on this list
+                       (comma separated)
+  --peers              Resend ICMP packets to this peer list
                        (comma separated)
   --help               Print this message
 
@@ -46,7 +50,8 @@ Once again, it listens waiting for packets matching:
      (ether dst not ff:ff:ff:ff:ff:ff)
 
 And having appropriate length, and forwards them to ethernet broadcast
-ff:ff:ff:ff:ff:ff.
+ff:ff:ff:ff:ff:ff or using normal packet routing if a list of peers
+is specified.
 
 To debug use tcpdump:
 

--- a/src/pmtud.h
+++ b/src/pmtud.h
@@ -43,11 +43,18 @@ int signal_desc(int signal);
 const char **parse_argv(const char *str, char delim);
 
 /* pcap.c */
+struct peer;
 pcap_t *setup_pcap(const char *iface, const char *bpf_filter, int snap_len,
 		   struct pcap_stat *stats);
 void unsetup_pcap(pcap_t *pcap, const char *iface, struct pcap_stat *stats);
 int setup_raw(const char *iface);
 const char *ip_to_string(const uint8_t *p, int p_len);
+void setup_rawipsocket(int *raw4, int *raw6);
+struct peer *make_peerlist(const char **addresses);
+void free_peerlist(struct peer *peer_list);
+int check_peerlist(struct peer *peer_list, const uint8_t *p, int p_len);
+void sendto_peerlist(struct peer *peer_list, int raw4, int raw6, int addr_len,
+    const uint8_t *icmppkt, unsigned icmppkt_len, int orig_ttl);
 
 /* sched.c */
 int taskset(int taskset_cpu);


### PR DESCRIPTION
First patch will add support for resending mtu messages to designated L3 peers. Second patch will add a direction filter to pcap, so only inboud packets are considered.
