### PR TITLE
Changes to make it run with the ixgbe adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,18 @@ ifeq ($(BUILD), release)
 	COPTSDEBUG=-g -ggdb -O3 $(MARCH)
 endif
 
-COPTS+=$(CFLAGS) $(COPTSDEBUG) $(COPTSWARN) $(COPTSSEC) -fPIE \
-	-Ideps/libpcap -I deps/libnfnetlink/include -Ideps/libnetfilter_log/include
+COPTS+=$(CFLAGS) $(COPTSDEBUG) $(COPTSWARN) $(COPTSSEC) -fPIE
 
 all: pmtud
 
-pmtud: libpcap.a libnetfilter_log.a libnfnetlink.a src/*.c src/*.h Makefile
+pmtud: src/*.c src/*.h Makefile
 	$(CC) $(COPTS) \
 		src/main.c src/utils.c src/net.c src/uevent.c \
 		src/hashlimit.c src/csiphash.c src/sched.c \
 		src/bitmap.c src/nflog.c \
-		libpcap.a libnetfilter_log.a libnfnetlink.a \
 		$(LDOPTS) \
-		-o pmtud
+		-o pmtud \
+		-lpcap -lnfnetlink -lnetfilter_log
 
 libpcap.a: deps/libpcap
 	(cd deps/libpcap && ./configure && make)

--- a/src/net.c
+++ b/src/net.c
@@ -29,9 +29,9 @@ pcap_t *setup_pcap(const char *iface, const char *bpf_filter, int snap_len,
 
 	int r;
 
-	r = pcap_set_tstamp_type(pcap, PCAP_TSTAMP_ADAPTER_UNSYNCED);
+	r = pcap_set_tstamp_type(pcap, PCAP_TSTAMP_HOST);
 	if (r != 0) {
-		pcap_set_tstamp_type(pcap, PCAP_TSTAMP_ADAPTER);
+		FATAL("pcap_set_tstamp_type: %s", pcap_geterr(pcap));
 	}
 
 	r = pcap_set_promisc(pcap, 0);


### PR DESCRIPTION
* Changed Makefile to make the binary dynamically linked
* Change `pcap_set_tstamp_type` to have value `PCAP_TSTAMP_HOST` as neither `PCAP_TSTAMP_ADAPTER` or `PCAP_TSTAMP_ADAPTER_UNSYNCED` works with the Intel ixgbe driver. `pcap_set_tstamp_type` doesn't error but it will fail at `pcap_activate`.
```bash
sudo pmtud --iface=eth1
[-] PROGRAM ABORT : pcap_activate("eth1"): SIOCSHWTSTAMP failed: Numerical result out of range
	Location : setup_pcap(), src/net.c:55
```
References:
* http://martinbj2008.github.io/blog/2016/01/29/hw-timestamp-in-tcpdump/
* https://github.com/the-tcpdump-group/tcpdump/issues/393

@Shopify/traffic