### PR TITLE
fix --strict option crash

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -427,6 +427,7 @@ int main(int argc, char *argv[])
 
 		case 't':
 			strict = 1;
+			break;
 
 		case 'r':
 			iface_rate = atof(optarg);


### PR DESCRIPTION
$ pmtud --strict
Segmentation fault (core dumped)

That's due unintentional fallthrough.

Signed-off-by: Sami Kerola <kerolasa@iki.fi>