### PR TITLE
Disable all libpcap build options not needed for pmtud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ pmtud: libpcap.a libnetfilter_log.a libnfnetlink.a src/*.c src/*.h Makefile
 		-o pmtud
 
 libpcap.a: deps/libpcap
-	(cd deps/libpcap && ./configure && make)
+	(cd deps/libpcap && ./configure --enable-usb=no --enable-bluetooth=no --enable-canusb=no --enable-can=no --enable-dbus=no --without-libnl && make)
 	cp deps/libpcap/libpcap.a .
 
 libnfnetlink.a: deps/libnfnetlink


### PR DESCRIPTION
Currently the `configure` script for libpcap is called without any arguments. Sadly this falls back to feature detection and may result in options which link to external libraries (breaks linking) or don't build on certain systems. This explicitly disables all unneeded features and should build under many more configurations.